### PR TITLE
Properly call super() with Python 2 syntax.

### DIFF
--- a/loki_handler/handlers.py
+++ b/loki_handler/handlers.py
@@ -46,7 +46,7 @@ class LokiHandler(logging.Handler):
     def handleError(self, record):  # noqa: N802
         """Close emitter and let default handler take actions on error."""
         self.emitter.close()
-        super().handleError(record)
+        super(LokiHandler, self).handleError(record)
 
     def emit(self, record):
         """Send log record to Loki."""


### PR DESCRIPTION
Corrected the error:

```
TypeErrorloki_handler.handlers in handleError
super() takes at least 1 argument (0 given)
```